### PR TITLE
update example for type shorthands

### DIFF
--- a/02-type-system-introduction/README.md
+++ b/02-type-system-introduction/README.md
@@ -91,6 +91,14 @@ Types can also be used with a shorthand syntax. In parameters, for instance, one
 type HelloWorld = string
 type PrimitiveArray = Array<string | number | boolean>
 
+// we can now use our type alias as a normal type...
+function print(): HelloWorld {
+  return 'Hello World'
+}
+
+var mixedArray: PrimitiveArray = [42, 'is', 'definitely', true]
+
+// ...or we can write an inline interface in parameters
 function getLabel (obj: { label: string }): string {
   return obj.label
 }


### PR DESCRIPTION
When introducing type shorthands (aliases),
the types that are defined weren't used in the code example.

Add an example of how to use them.
